### PR TITLE
Support for Ubuntu 16.04, Centos 6, Centos 7, and some other tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+.kitchen-cloud.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,8 +8,16 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
 
+verifier:
+  name: inspec
+
 suites:
   - name: default
     run_list:
       - recipe[aws-cloudwatchlogs::default]
+    verifier:
+      inspec_tests:
+        - test/smoke/default
     attributes:
+      aws_cwlogs:
+        region: us-east-1

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,10 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
+  - name: centos-6
+  - name: centos-7
+
 
 verifier:
   name: inspec

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -16,3 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'aws-cloudwatchlogs::install'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -15,42 +15,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-# always keep aws.conf updated
-template "#{node['aws_cwlogs']['path']}/etc/aws.conf" do
-   source 'aws.conf.erb'
-   owner 'root'
-   group 'root'
-   mode 0600
-   variables ({
-      :awsRegion => node['aws_cwlogs']['region'],
-      :awsAccessKey => node['aws_cwlogs']['aws_access_key_id'],
-      :awsSecretKey => node['aws_cwlogs']['aws_secret_access_key']
-   })
-end
-
-# always keep logging.conf updated
-template "#{node['aws_cwlogs']['path']}/etc/logging.conf" do
-   source 'logging.conf.erb'
-   owner 'root'
-   group 'root'
-   mode 0600
-end
-
-# always generate awslogs.conf based on default
-# attributes related to log files
-template "#{node['aws_cwlogs']['path']}/etc/awslogs.conf" do
-   source 'awslogs.conf.erb'
-   owner 'root'
-   group 'root'
-   mode 0644
-end
-
-# always restart aws cloudwatch logs agent
-# after the configuration files were updated
-service 'awslogs' do
-   action [:enable, :restart]
-   supports :restart => true, :status => true, :start => true, :stop => true
-   subscribes :restart, "template [#{node['aws_cwlogs']['path']}/etc/awslogs.conf]", :delayed
-end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,5 +17,4 @@
 # limitations under the License.
 #
 
-# only install if it isn't installed
 include_recipe 'aws-cloudwatchlogs::install'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,12 +17,5 @@
 # limitations under the License.
 #
 
-if node['aws_cwlogs']['region'].nil?
-   log('AWS Region is necessary for this cookbook.') { level :error }
-   return
-end
-
 # only install if it isn't installed
-include_recipe 'aws-cloudwatchlogs::install' unless ::File.exist?(node['aws_cwlogs']['path'])
-# always reconfigure aws cloudwatch logs configuration files
-include_recipe 'aws-cloudwatchlogs::config'
+include_recipe 'aws-cloudwatchlogs::install'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -70,7 +70,7 @@ end
 
 package 'python'
 package 'epel-release' if node[:platform_family] == 'rhel'
-package 'python-pip'
+package 'python-pip' if node[:platform_family] == 'rhel'
 
 # install aws cloudwatch logs agent
 execute 'Install CloudWatch Logs Agent' do

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -68,6 +68,10 @@ remote_file "#{node['aws_cwlogs']['path']}/awslogs-agent-setup.py" do
    mode 0755
 end
 
+package 'python'
+package 'epel-release' if node[:platform_family] == 'rhel'
+package 'python-pip'
+
 # install aws cloudwatch logs agent
 execute 'Install CloudWatch Logs Agent' do
    command "#{node['aws_cwlogs']['path']}/awslogs-agent-setup.py -n -r #{node['aws_cwlogs']['region']} -c /tmp/awslogs.cfg"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,6 +17,15 @@
 # limitations under the License.
 #
 
+if node['aws_cwlogs']['region'].nil?
+  if node['ec2'] && node['ec2']['region']
+    node.normal['aws_cwlogs']['region'] = node['ec2']['region']
+  else
+    log('AWS Region is necessary for this cookbook.') { level :error }
+    return
+  end
+end
+
 # create base directory of agent even if it isn't installed yet
 directory "#{node['aws_cwlogs']['path']}/etc" do
   recursive true
@@ -32,6 +41,7 @@ template "#{node['aws_cwlogs']['path']}/etc/aws.conf" do
       :awsAccessKey => node['aws_cwlogs']['aws_access_key_id'],
       :awsSecretKey => node['aws_cwlogs']['aws_secret_access_key']
    })
+   notifies :restart, 'service[awslogs]', :delayed
 end
 
 template "#{node['aws_cwlogs']['path']}/etc/logging.conf" do
@@ -39,6 +49,7 @@ template "#{node['aws_cwlogs']['path']}/etc/logging.conf" do
    owner 'root'
    group 'root'
    mode 0600
+   notifies :restart, 'service[awslogs]', :delayed
 end
 
 template '/tmp/awslogs.cfg' do
@@ -46,6 +57,7 @@ template '/tmp/awslogs.cfg' do
    owner 'root'
    group 'root'
    mode 0644
+   notifies :restart, 'service[awslogs]', :delayed
 end
 
 # download setup script that will install aws cloudwatch logs agent
@@ -59,12 +71,12 @@ end
 # install aws cloudwatch logs agent
 execute 'Install CloudWatch Logs Agent' do
    command "#{node['aws_cwlogs']['path']}/awslogs-agent-setup.py -n -r #{node['aws_cwlogs']['region']} -c /tmp/awslogs.cfg"
-   not_if { system 'pgrep -f awslogs' }
+   creates "#{node['aws_cwlogs']['path']}/bin/awslogs-agent-launcher.sh"
 end
 
 # restart the agent service in the end to ensure that
 # the agent will run with the custom configurations
 service 'awslogs' do
-   action [:enable, :restart]
+   action [:enable, :start]
    supports :restart => true, :status => true, :start => true, :stop => true
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe 'aws-cloudwatchlogs::default' do
-  # Serverspec examples can be found at
-  # http://serverspec.org/resource_types.html
-  it 'does something' do
-    skip 'Replace this with meaningful tests'
-  end
-end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,8 +1,0 @@
-require 'serverspec'
-
-if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
-  set :backend, :exec
-else
-  set :backend, :cmd
-  set :os, family: 'windows'
-end

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -1,0 +1,6 @@
+
+describe service('awslogs') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end


### PR DESCRIPTION
Couple things to note:
   I did NOT bump the version in the metadata, because Im not sure if I broke the interface for the config recipe ( see below).
   I changed the idempotence test for the install to a specific file (/var/awslogs/bin/awslogs-agent-launcher.sh_ instead of the /var/awslogs directory, because that  directory gets created even before the agent is successfully installed (thus it never retries if it fails to install).
  I change the service to enable and start, instead of restart every time, and then set up notifications from the template files to restart if changed.  
   I wasn't sure why one would ever use the config recipe - wouldn't you always want to make sure it is installed too? Too keep it compatible though, I just set the config recipe to include the install recipe.
  I added code to set the region based on the instance's region in ohai, but only if the attribute isn't set or overridden, and the ohai attribute exists
I added some inspec tests, and more platforms in the .kitchen.yml
