### PR TITLE
Add service definition to aws_cwlogs provider. Fixes github issue #5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changes
 =======
 
+# 1.1.7 / 2017-11-21
+* Fixed 'service resource not found' error.
+
 # 1.1.6 / 2017-02-22
 * Removed the requirement for `aws_access_key_id` and `aws_secret_access_key` attributes values.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Agent and deploy it's configurations automatically.
 Add this cookbook to your base recipe:
 
 ```ruby
-cookbook 'aws-cloudwatchlogs', '~> 1.1.6'
+cookbook 'aws-cloudwatchlogs', '~> 1.1.7'
 ```
 
 You need to configure the following node attributes via an `environment` or `role`:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'alexandre@malucelli.net'
 license 'Apache-2.0'
 description 'Install and Configure AWS CloudWatch Logs Agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.6'
+version '1.1.7'
 source_url 'https://github.com/amalucelli/chef-cloudwatchlogs' if respond_to? :source_url
 issues_url 'https://github.com/amalucelli/chef-cloudwatchlogs/issues' if respond_to? :issues_url
 

--- a/providers/aws_cwlogs.rb
+++ b/providers/aws_cwlogs.rb
@@ -21,6 +21,9 @@ provides :aws_cwlogs if respond_to?(:provides)
 use_inline_resources if defined?(use_inline_resources)
 
 action :add do
+   service 'awslogs' do
+      action :nothing
+   end
    Chef::Log.debug "Adding configuration for #{new_resource.name}"
    template ::File.join(node['aws_cwlogs']['path'], 'etc/config', "#{new_resource.name}.conf") do
       owner 'root'
@@ -36,6 +39,9 @@ action :add do
 end
 
 action :remove do
+   service 'awslogs' do
+      action :nothing
+   end
    conf_path = ::File.join(node['aws_cwlogs']['path'], 'etc/config')
    Chef::Log.debug "Removing #{new_resource.name} from #{conf_path}"
    file ::File.join(node['aws_cwlogs']['path'], 'etc/config', "#{new_resource.name}.conf") do


### PR DESCRIPTION
Fixes #5. I looked for a way to duplicate this error in chefspec or test-kitchen, but it happens when I use the `aws_cwlogs` resource and I didn't see a way to mock that into any of the tests without adding a recipe. However, I made this modification in the environment where I found the bug and it worked. Existing chefspecs and kitchen tests still pass.

Can you take a look? Thanks!